### PR TITLE
Fix emoji rendering in routes

### DIFF
--- a/calamity/Calamity/HTTP/Channel.hs
+++ b/calamity/Calamity/HTTP/Channel.hs
@@ -204,6 +204,10 @@ baseRoute id =
   mkRouteBuilder // S "channels" // ID @Channel
     & giveID id
 
+renderEmoji :: RawEmoji -> Text
+renderEmoji (UnicodeEmoji e) = e ^. strict
+renderEmoji (CustomEmoji e) = e ^. #name . strict <> ":" <> showt (e ^. #id)
+
 instance Request (ChannelRequest a) where
   type Result (ChannelRequest a) = a
 
@@ -231,20 +235,20 @@ instance Request (ChannelRequest a) where
       & giveID mid
       & buildRoute
   route (CreateReaction (getID -> cid) (getID @Message -> mid) emoji) =
-    baseRoute cid // S "messages" // ID @Message // S "reactions" // S (showt emoji) // S "@me"
+    baseRoute cid // S "messages" // ID @Message // S "reactions" // S (renderEmoji emoji) // S "@me"
       & giveID mid
       & buildRoute
   route (DeleteOwnReaction (getID -> cid) (getID @Message -> mid) emoji) =
-    baseRoute cid // S "messages" // ID @Message // S "reactions" // S (showt emoji) // S "@me"
+    baseRoute cid // S "messages" // ID @Message // S "reactions" // S (renderEmoji emoji) // S "@me"
       & giveID mid
       & buildRoute
   route (DeleteUserReaction (getID -> cid) (getID @Message -> mid) emoji (getID @User -> uid)) =
-    baseRoute cid // S "messages" // ID @Message // S "reactions" // S (showt emoji) // ID @User
+    baseRoute cid // S "messages" // ID @Message // S "reactions" // S (renderEmoji emoji) // ID @User
       & giveID mid
       & giveID uid
       & buildRoute
   route (GetReactions (getID -> cid) (getID @Message -> mid) emoji _) =
-    baseRoute cid // S "messages" // ID @Message // S "reactions" // S (showt emoji)
+    baseRoute cid // S "messages" // ID @Message // S "reactions" // S (renderEmoji emoji)
       & giveID mid
       & buildRoute
   route (DeleteAllReactions (getID -> cid) (getID @Message -> mid)) =


### PR DESCRIPTION
The current behavior for rendering `CreateRaction` and co. requests with `CustomEmoji` is as so
```hs
λ> renderUrl $ view #path $ route $ CreateReaction  (Snowflake @Channel 123 ) (Snowflake @Message 456) (CustomEmoji (PartialEmoji (Snowflake 123) "abc"  False))
"https://discord.com/api/v8/channels/123/messages/456/reactions/<:abc:123>/@me"
```
This results in a `NUMBER_TYPE_COERCE` error from Discord since, [as the documentation specifies](https://discord.com/developers/docs/resources/channel#create-reaction), the correct format is `name:id`.
The following pull request fixes this issue and gives the behavior:
```hs
λ> renderUrl $ view #path $ route $ CreateReaction  (Snowflake @Channel 123 ) (Snowflake @Message 456) (CustomEmoji (PartialEmoji (Snowflake 123) "abc"  False))
"https://discord.com/api/v8/channels/123/messages/456/reactions/abc:123/@me"
```