### PR TITLE
fix ModifyChannel request http method

### DIFF
--- a/calamity/Calamity/HTTP/Channel.hs
+++ b/calamity/Calamity/HTTP/Channel.hs
@@ -320,7 +320,7 @@ instance Request (ChannelRequest a) where
     postWith' body u o
   action (CrosspostMessage _ _) = postEmpty
   action (GetChannel _) = getWith
-  action (ModifyChannel _ p) = putWith' (ReqBodyJson p)
+  action (ModifyChannel _ p) = patchWith' (ReqBodyJson p)
   action (DeleteChannel _) = deleteWith
   action (GetChannelMessages _ (Just (ChannelMessagesAround (fromSnowflake -> a))) l) =
     getWithP ("around" =: a <> "limit" =:? (l ^? _Just . #limit))


### PR DESCRIPTION
The `Modify Channel` request method should be `PATCH`, not `PUT`. The current implementation will error with 

```json
{
    "code": 50035,
    "errors": {
        "name": {
            "_errors": [
                {
                    "code": "BASE_TYPE_REQUIRED",
                    "message": "This field is required"
                }
            ]
        }
    },
    "message": "Invalid Form Body"
}
```