### PR TITLE
Fix ambiguity error in `command` function

### DIFF
--- a/calamity-commands/CalamityCommands/CommandUtils.hs
+++ b/calamity-commands/CalamityCommands/CommandUtils.hs
@@ -116,7 +116,7 @@ buildCommand ::
   P.Sem r (Command m c a)
 buildCommand names parent hidden checks help command =
   let (parser, cb) = buildTypedCommand @ps command
-   in buildCommand' names parent hidden checks (parameterInfos @ps @r) help parser cb
+   in buildCommand' names parent hidden checks (parameterInfos @ps @c @r) help parser cb
 
 {- | Given the name of the command the parser is for and a parser function in
  the 'P.Sem' monad, build a parser by transforming the Polysemy action into an
@@ -164,7 +164,7 @@ type TypedCommandC ps c a r =
   ( ApplyTupRes (ParserResult (ListToTup ps)) (CommandSemType r a) ~ CommandForParsers ps r a
   , ParameterParser (ListToTup ps) c r
   , ApplyTup (ParserResult (ListToTup ps)) (CommandSemType r a)
-  , ParameterInfoForParsers ps r
+  , ParameterInfoForParsers ps c r
   )
 
 buildTypedCommand ::
@@ -179,14 +179,14 @@ buildTypedCommand cmd =
       consumer (ctx, r) = applyTup (cmd ctx) r
    in (parser, consumer)
 
-class ParameterInfoForParsers (ps :: [Type]) r where
+class ParameterInfoForParsers (ps :: [Type]) c r where
   parameterInfos :: [ParameterInfo]
 
-instance ParameterInfoForParsers '[] r where
+instance ParameterInfoForParsers '[] c r where
   parameterInfos = []
 
-instance (ParameterParser x c r, ParameterInfoForParsers xs r) => ParameterInfoForParsers (x : xs) r where
-  parameterInfos = parameterInfo @x @c @r : parameterInfos @xs @r
+instance (ParameterParser x c r, ParameterInfoForParsers xs c r) => ParameterInfoForParsers (x : xs) c r where
+  parameterInfos = parameterInfo @x @c @r : parameterInfos @xs @c @r
 
 class ApplyTup a b where
   type ApplyTupRes a b


### PR DESCRIPTION
Running the following command in GHCi gives an interesting error message

```
λ> :t (command @'[Member] "test" $ \(_ctx :: FullContext) _ -> pure ())

<interactive>:1:2: error:
    • Could not deduce (Calamity.Commands.Context.CalamityCommandContext
                          c0)
        arising from a use of ‘command’
      from the context: (Polysemy.Internal.Union.Find
                           (Polysemy.Final.Final IO) r,
                         Polysemy.Internal.Union.Find Calamity.Cache.Eff.CacheEff r,
                         Polysemy.Internal.Union.LocateEffect (Polysemy.Final.Final IO) r
                         ~ '(),
                         Polysemy.Internal.Union.LocateEffect Calamity.Cache.Eff.CacheEff r
                         ~ '())
        bound by the inferred type of
                   it :: (Polysemy.Internal.Union.Find (Polysemy.Final.Final IO) r,
                          Polysemy.Internal.Union.Find Calamity.Cache.Eff.CacheEff r,
                          Polysemy.Internal.Union.LocateEffect (Polysemy.Final.Final IO) r
                          ~ '(),
                          Polysemy.Internal.Union.LocateEffect Calamity.Cache.Eff.CacheEff r
                          ~ '()) =>
                         Polysemy.Internal.Sem
                           (DSLState FullContext r)
                           (Calamity.Commands.Types.Command FullContext)
        at <interactive>:1:1
      The type variable ‘c0’ is ambiguous
      These potential instances exist:
        instance Calamity.Commands.Context.CalamityCommandContext
                   FullContext
          -- Defined at Calamity/Commands/Context.hs:68:10
        ...plus one instance involving out-of-scope types
        (use -fprint-potential-instances to see them all)
    • In the expression: command @'[Member] "test"
      In the expression:
        (command @'[Member] "test" $ \ (_ctx :: FullContext) _ -> pure ())     
```
GHC complains about some `c0` type variable that doesn't appear anywhere else. Interestingly, this only appears for certain types. If we replace `Member` with `Int` then it typechecks.
After some digging, the culprit seems to be 
```hs
type TypedCommandC ps c a r =
   [...]
  , ParameterInfoForParsers ps r
  )
...
class ParameterInfoForParsers (ps :: [Type]) r where
...
instance (ParameterParser x c r, ParameterInfoForParsers xs r) => ParameterInfoForParsers (x : xs) r where
...

```
Aha! We've introduced a new type variable `c` that's unrelated to the one mentioned in the type signature of `command`, leading to the ambiguity error.  `ParameterParser` in turn requires `ParameterParser` in certain instances. Namely, the instances for types that cause the expression to not typecheck (such as `Member`).
The fix is simple, add `c` to the typeclass parameters of `ParameterInfoForParsers` to ensure it's the same `c`.