### PR TITLE
Remove types section from help when unneeded

### DIFF
--- a/calamity-commands/CalamityCommands/Help.hs
+++ b/calamity-commands/CalamityCommands/Help.hs
@@ -37,7 +37,9 @@ parameterTypeHelp :: [ParameterInfo] -> L.Text
 parameterTypeHelp pinfo =
   let dedup = LH.toList . LH.fromList $ map (\(ParameterInfo _ t d) -> (t, d)) pinfo
       typeDescs = L.unlines ["- " <> L.pack (show t) <> ": " <> L.fromStrict d | (t, d) <- dedup]
-  in "Types:\n" <> typeDescs <> "\n"
+  in if null dedup
+      then ""
+      else "Types:\n" <> typeDescs <> "\n"
 
 helpCommandHelp :: c -> L.Text
 helpCommandHelp _ = "Show help for a command or group."


### PR DESCRIPTION
Currently, a command with no arguments will have an empty `Types` section in the generated help command output. This PR removes the section if the list of types is empty.