### PR TITLE
GHC 9.0.1 Compatability

### DIFF
--- a/calamity-commands/calamity-commands.cabal
+++ b/calamity-commands/calamity-commands.cabal
@@ -112,7 +112,7 @@ library
     , lens >=4.18 && <6
     , megaparsec >=8 && <10
     , polysemy >=1.5 && <2
-    , polysemy-plugin ==0.3.*
+    , polysemy-plugin >=0.3 && <0.5
     , text >=1.2 && <2
     , text-show >=3.8 && <4
     , unordered-containers ==0.2.*

--- a/calamity-commands/package.yaml
+++ b/calamity-commands/package.yaml
@@ -31,7 +31,7 @@ dependencies:
 - text >= 1.2 && < 2
 - unordered-containers >= 0.2 && < 0.3
 - polysemy >= 1.5 && < 2
-- polysemy-plugin >= 0.3 && < 0.4
+- polysemy-plugin >= 0.3 && < 0.5
 - text-show >= 3.8 && < 4
 - megaparsec >= 8 && < 10
 

--- a/calamity/calamity.cabal
+++ b/calamity/calamity.cabal
@@ -213,7 +213,7 @@ library
     , mime-types ==0.1.*
     , mtl >=2.2 && <3
     , polysemy >=1.5 && <2
-    , polysemy-plugin ==0.3.*
+    , polysemy-plugin >=0.3 && <0.5
     , reflection >=2.1 && <3
     , req >=3.1 && <3.10
     , safe-exceptions >=0.1 && <2

--- a/calamity/package.yaml
+++ b/calamity/package.yaml
@@ -59,7 +59,7 @@ dependencies:
 - vector >= 0.12 && < 0.13
 - reflection >= 2.1 && < 3
 - polysemy >= 1.5 && < 2
-- polysemy-plugin >= 0.3 && < 0.4
+- polysemy-plugin >= 0.3 && < 0.5
 - di-polysemy >= 0.2 && < 0.3
 - df1 >= 0.4 && < 0.5
 - di-core >= 1.0.4 && < 1.1


### PR DESCRIPTION
Bumps the upper bounds on polysemy-plugin in order to get calamity and calamity-commands building under GHC-9.0.1

I have only confirmed that the package successfully builds since there are no tests, but polysemy-plugin's changelog lists no breaking changes.