### PR TITLE
Fix x509 type conflict (happened after tls update to 1.7)

### DIFF
--- a/calamity/calamity.cabal
+++ b/calamity/calamity.cabal
@@ -195,7 +195,8 @@ library
     , calamity-commands     >=0.4     && <0.5
     , colour                >=2.3.5   && <2.4
     , concurrent-extra      >=0.7     && <0.8
-    , connection            >=0.2.6   && <0.4
+    , crypton-connection    >=0.2.6   && <0.4
+    , crypton-x509-system   >=1.6.6   && <1.7
     , containers            >=0.6     && <0.7
     , data-default-class    >=0.1     && <0.2
     , data-flags            >=0.0.3   && <0.1
@@ -235,6 +236,5 @@ library
     , unordered-containers  >=0.2     && <0.3
     , vector                >=0.12    && <0.14
     , websockets            >=0.12    && <0.13
-    , x509-system           >=1.6.6   && <1.7
 
   default-language:   Haskell2010


### PR DESCRIPTION
Changelog for tls-1.7.0
Major version up because "crypton" is used instead of "cryptonite"

without this commit:

```haskell
    • Couldn't match expected type ‘Data.X509.CertificateStore.CertificateStore’
                  with actual type ‘x509-store-1.6.9:Data.X509.CertificateStore.CertificateStore’
      NB: ‘Data.X509.CertificateStore.CertificateStore’
            is defined in ‘Data.X509.CertificateStore’
                in package ‘crypton-x509-store-1.6.9’
          ‘x509-store-1.6.9:Data.X509.CertificateStore.CertificateStore’
            is defined in ‘Data.X509.CertificateStore’
                in package ‘x509-store-1.6.9’
    • In the ‘sharedCAStore’ field of a record
      In the ‘clientShared’ field of a record
      In the expression:
        (NT.defaultParamsClient (T.unpack host) "443")
          {NT.clientSupported = def
                                  {NT.supportedCiphers = NT.ciphersuite_default},
           NT.clientShared = def {NT.sharedCAStore = certStore}}
    |
136 |                   { NT.sharedCAStore = certStore
    |                                        ^^^^^^^^^
    ```