### PR TITLE
use RequestBody for attachment content

### DIFF
--- a/calamity/Calamity/HTTP/Interaction.hs
+++ b/calamity/Calamity/HTTP/Interaction.hs
@@ -324,7 +324,7 @@ instance Request (InteractionRequest a) where
      in postWith' (ReqBodyJson jsonBody)
   action (CreateResponseMessage _ _ cm) = \u o -> do
     let filePart CreateMessageAttachment {filename, content} n =
-          (partLBS @IO (T.pack $ "files[" <> show n <> "]") content)
+          (partFileRequestBody @IO (T.pack $ "files[" <> show n <> "]") "" content)
             { partFilename = Just (T.unpack filename)
             , partContentType = Just (defaultMimeLookup filename)
             }
@@ -354,7 +354,7 @@ instance Request (InteractionRequest a) where
     postWith' body u o
   action (CreateResponseUpdate _ _ cm) = \u o -> do
     let filePart CreateMessageAttachment {filename, content} n =
-          (partLBS @IO (T.pack $ "files[" <> show n <> "]") content)
+          (partFileRequestBody @IO (T.pack $ "files[" <> show n <> "]") "" content)
             { partFilename = Just (T.unpack filename)
             , partContentType = Just (defaultMimeLookup filename)
             }
@@ -399,7 +399,7 @@ instance Request (InteractionRequest a) where
   action (GetOriginalInteractionResponse _ _) = getWith
   action (EditOriginalInteractionResponse _ _ cm) = \u o -> do
     let filePart CreateMessageAttachment {filename, content} n =
-          (partLBS @IO (T.pack $ "files[" <> show n <> "]") content)
+          (partFileRequestBody @IO (T.pack $ "files[" <> show n <> "]") "" content)
             { partFilename = Just (T.unpack filename)
             , partContentType = Just (defaultMimeLookup filename)
             }
@@ -430,7 +430,7 @@ instance Request (InteractionRequest a) where
   action (DeleteOriginalInteractionResponse _ _) = deleteWith
   action (CreateFollowupMessage _ _ cm) = \u o -> do
     let filePart CreateMessageAttachment {filename, content} n =
-          (partLBS @IO (T.pack $ "files[" <> show n <> "]") content)
+          (partFileRequestBody @IO (T.pack $ "files[" <> show n <> "]") "" content)
             { partFilename = Just (T.unpack filename)
             , partContentType = Just (defaultMimeLookup filename)
             }
@@ -456,7 +456,7 @@ instance Request (InteractionRequest a) where
   action GetFollowupMessage {} = getWith
   action (EditFollowupMessage _ _ _ cm) = \u o -> do
     let filePart CreateMessageAttachment {filename, content} n =
-          (partLBS @IO (T.pack $ "files[" <> show n <> "]") content)
+          (partFileRequestBody @IO (T.pack $ "files[" <> show n <> "]") "" content)
             { partFilename = Just (T.unpack filename)
             , partContentType = Just (defaultMimeLookup filename)
             }

--- a/calamity/Calamity/HTTP/Webhook.hs
+++ b/calamity/Calamity/HTTP/Webhook.hs
@@ -183,7 +183,7 @@ instance Request (WebhookRequest a) where
   action (DeleteWebhookToken _ _) = deleteWith
   action (ExecuteWebhook _ _ wh) = \u o -> do
     let filePart CreateMessageAttachment {filename, content} n =
-          (partLBS @IO (T.pack $ "files[" <> show n <> "]") content)
+          (partFileRequestBody @IO (T.pack $ "files[" <> show n <> "]") "" content)
             { partFilename = Just (T.unpack filename)
             , partContentType = Just (defaultMimeLookup filename)
             }


### PR DESCRIPTION
This PR let's people use a `RequestBody` instead of Lazy Bytestring to create an attachment. This gives people more fine grained control on how the content of the attachment is loaded. For example, in my use case, I had to load a file from Amazon S3, and upload it as an attachment. However due to the memory limit of the VM I'm running the bot on, it would crash due to OOM if I try to upload a huge file. Fiddling with Lazy Bytestring wasn't yielding any good results so I came up with this PR.

With this PR, I can upload a `body :: ConduitM () ByteString (ResourceT IO) ()` with `requestBodySourceChunked` from http-conduit, without running into memory problems.

```haskell
let file = CreateMessageAttachment filename Nothing $ requestBodySourceChunked body
followUp (intoMsg ([i|<@#{showID $ user ^. #id}>|] :: Text) <> intoMsg file)
  ```