### PR TITLE
on mtl 2.3+ Control.Monad.State.Lazy is not exporting (when)

### DIFF
--- a/calamity/Calamity/Internal/BoundedStore.hs
+++ b/calamity/Calamity/Internal/BoundedStore.hs
@@ -12,7 +12,8 @@ module Calamity.Internal.BoundedStore (
 
 import Calamity.Internal.Utils (unlessM, whenM)
 import Calamity.Types.Snowflake (HasID (getID), HasID', Snowflake)
-import Control.Monad.State.Lazy (execState, when)
+import Control.Monad.State.Lazy (execState)
+import Control.Monad (when)
 import Data.Default.Class (Default (..))
 import Data.HashMap.Strict (HashMap)
 import Data.HashMap.Strict qualified as H


### PR DESCRIPTION
![image](https://github.com/simmsb/calamity/assets/38455533/624d07d7-7019-4713-8e36-acb5a52af8aa)
