### PR TITLE
Fix a bit of syntax

### DIFF
--- a/calamity/Calamity/Internal/Utils.hs
+++ b/calamity/Calamity/Internal/Utils.hs
@@ -184,7 +184,7 @@ _ .?= Nothing = Nothing
 k .= v = Just (k Aeson..= v)
 
 class CalamityToJSON' a where
-  toPairs :: Aeson.KeyValue kv => a -> [Maybe kv]
+  toPairs :: Aeson.KeyValue v kv => a -> [Maybe kv]
 #else
 (.?=) :: (Aeson.ToJSON v, Aeson.KeyValue kv) => Aeson.Key -> Maybe v -> Maybe kv
 k .?= Just v = Just (k Aeson..= v)

--- a/calamity/calamity.cabal
+++ b/calamity/calamity.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.0
 name:               calamity
-version:            0.12.0.0
+version:            0.12.1.0
 synopsis:           A library for writing discord bots in haskell
 description:
   Please see the README on GitHub at <https://github.com/simmsb/calamity#readme>


### PR DESCRIPTION
Note that this requires 

```
source-repository-package
    type: git
    location: https://github.com/L0neGamer/typerep-map.git
    tag: 43026d99e1b63d049e8e79641c2e7972a5611629
```

to test as typerep has old deps, and you can't even use aeson 2.2+

Fixes #73 